### PR TITLE
[Fix] AWS Personalize 추천 json 변경

### DIFF
--- a/Server/bookmark/controller/bookmark.controller.js
+++ b/Server/bookmark/controller/bookmark.controller.js
@@ -2,20 +2,19 @@ import Bookmark from "../model/bookmark.model.js";
 import User from "../../user/model/user.model.js";
 import Alcohol from "../../alcohol/model/alcohol.model.js";
 import {
-  sendBookmarkEvent,
-  sendReviewEvent,
-  sendViewDetailEvent,
+  sendBookmarkEvent
 } from "../../personalize/service/personalize.service.js";
 
 
 
 // 북마크 추가
 export const addBookmark = async (req, res) => {
-  const { userId, alcoholId } = req.body;
+  const { userId, alcoholIndex } = req.body;
 
   try {
     const user = await User.findById(userId);
-    const alcohol = await Alcohol.findById(alcoholId);
+    // findById 대신 findOne으로 index 필드 검색
+    const alcohol = await Alcohol.findOne({ index: alcoholIndex });
 
     if (!user || !alcohol) {
       return res
@@ -24,16 +23,17 @@ export const addBookmark = async (req, res) => {
     }
 
     // 중복 체크
-    const exists = await Bookmark.findOne({ userId, alcoholId });
+    const exists = await Bookmark.findOne({ userId, alcoholId: alcohol._id });
     if (exists) {
       return res.status(400).json({ message: "이미 북마크된 전통주입니다." });
     }
 
-    const bookmark = new Bookmark({ userId, alcoholId });
+    // db에는 _id로 저장
+    const bookmark = new Bookmark({ userId, alcoholId: alcohol._id });
     await bookmark.save();
 
     // Personalize에 이벤트 전송
-    await sendBookmarkEvent(userId, alcoholId.toString());
+    await sendBookmarkEvent(userId, alcohol.index.toString());
 
     res.status(201).json({ message: "북마크 완료", bookmark });
   } catch (err) {

--- a/Server/chatbot/service/chatbot.service.js
+++ b/Server/chatbot/service/chatbot.service.js
@@ -87,7 +87,8 @@ export async function recommendSool(userId, userQuestion) {
 3. imageURL도 주어진 전통주 목록에 있는 imageURL을 사용하세요.
 4. reason은 사용자의 질문과 이 전통주를 추천한 이유를 논리적으로 설명하세요.
 5. 추천 리스트 전에 "~~한 질문에 맞는 전통주 3가지를 추천했어요."와 같은 answer 문장을 JSON 형식으로 추가하세요.
-6. 반드시 아래 JSON 구조 하나만 반환하세요:
+6. detailPage는 http://13.209.223.34:3000/alcohols/ 에 해당 전통주의 index를 붙여 반환하세요.
+7. 반드시 아래 JSON 구조 하나만 반환하세요:
 {
   "answer": "김치전에 어울리는 전통주 3가지를 추천했어요.",
   "result": [
@@ -96,7 +97,7 @@ export async function recommendSool(userId, userQuestion) {
     "description": "전통주 특징 요약",
     "reason": "전통주 추천 이유",
     "imageURL": "이미지 URL",
-    "detailPage": "상세페이지 URL"
+    "detailPage": "http://13.209.223.34:3000/alcohols/{alcohol_id}"
     },  
   ...
   ]

--- a/Server/chatbot/service/chatbot.service.js
+++ b/Server/chatbot/service/chatbot.service.js
@@ -87,7 +87,7 @@ export async function recommendSool(userId, userQuestion) {
 3. imageURL도 주어진 전통주 목록에 있는 imageURL을 사용하세요.
 4. reason은 사용자의 질문과 이 전통주를 추천한 이유를 논리적으로 설명하세요.
 5. 추천 리스트 전에 "~~한 질문에 맞는 전통주 3가지를 추천했어요."와 같은 answer 문장을 JSON 형식으로 추가하세요.
-6. detailPage는 http://13.209.223.34:3000/alcohols/ 에 해당 전통주의 index를 붙여 반환하세요.
+6. alcoholId는 해당 전통주의 index를 반환하세요.
 7. 반드시 아래 JSON 구조 하나만 반환하세요:
 {
   "answer": "김치전에 어울리는 전통주 3가지를 추천했어요.",
@@ -97,13 +97,13 @@ export async function recommendSool(userId, userQuestion) {
     "description": "전통주 특징 요약",
     "reason": "전통주 추천 이유",
     "imageURL": "이미지 URL",
-    "detailPage": "http://13.209.223.34:3000/alcohols/{alcohol_id}"
+    "alcoholId": alcohol_id
     },  
   ...
   ]
 }
-7. 추천 순서는 관련도 순으로 가장 잘 맞는 술부터 배치하세요.
-8. 추천 항목마다 줄바꿈과 구분을 통해 사용자 입장에서 보기 쉽게 구성하세요.
+8. 추천 순서는 관련도 순으로 가장 잘 맞는 술부터 배치하세요.
+9. 추천 항목마다 줄바꿈과 구분을 통해 사용자 입장에서 보기 쉽게 구성하세요.
 
 ### 데이터 제한 조건:
 

--- a/Server/data_seed.js
+++ b/Server/data_seed.js
@@ -196,7 +196,7 @@ async function seedAllData() {
         await Festival.insertMany(festivalData);
         console.log(`축제 데이터 삽입 완료\n`);
 
-        const csvFile = fs.readFileSync('./Server/alcohol_crawl/real_final.csv', 'utf8');
+        const csvFile = fs.readFileSync('./alcohol_crawl/real_final.csv', 'utf8');
         
         await new Promise((resolve, reject) => {
             Papa.parse(csvFile, {

--- a/Server/recommend/aws-recommend/controller/recommend.controller.js
+++ b/Server/recommend/aws-recommend/controller/recommend.controller.js
@@ -4,7 +4,7 @@ export const recommendController = async (req, res) => {
   try {
     const userId = req.params.userId;
     const recommendations = await getRecommendations(userId);
-    res.json({ userId, recommendations });
+    res.json({ recommendations });
   } catch (error) {
     res.status(500).json({ message: "추천 실패", error });
   }

--- a/Server/recommend/aws-recommend/service/recommend.service.js
+++ b/Server/recommend/aws-recommend/service/recommend.service.js
@@ -1,5 +1,6 @@
 import { GetRecommendationsCommand } from "@aws-sdk/client-personalize-runtime";
 import { personalizeClient } from "../../../config/personalize.js";
+import Alcohol from "../../../alcohol/model/alcohol.model.js"
 
 export const getRecommendations = async (userId = "1", numResults = 6) => {
   const command = new GetRecommendationsCommand({
@@ -9,10 +10,60 @@ export const getRecommendations = async (userId = "1", numResults = 6) => {
   });
 
   try {
-    const response = await personalizeClient.send(command);
-    return response.itemList;
+    // Personalize에서 추천 전통주 id 목록 받기
+    const personalizeResponse = await personalizeClient.send(command);
+    // 추천 결과가 없으면 빈 배열 반환
+    if (
+      !personalizeResponse.itemList ||
+      personalizeResponse.itemList.length === 0
+    ) {
+      return [];
+    }
+    // ID만 담긴 배열로 변환
+    const recommendedItemIds = personalizeResponse.itemList.map(
+      (item) => item.itemId
+    );
+    const indexIds = [];
+    const objectIds = [];
+    console.log(recommendedItemIds)
+
+    recommendedItemIds.forEach((id) => {
+      // ID가 숫자 형태인지 확인 (예: "1", "123")
+      if (/^\d+$/.test(id)) {
+        indexIds.push(id);
+      } else {
+        // 숫자 형태가 아니면 _id로 간주
+        objectIds.push(id);
+      }
+    });
+    // ID 목록으로 MongoDB에서 아이템 상세 정보 조회
+    const itemDetailsFromDB = await Alcohol.find({
+      $or: [{ index: { $in: indexIds } }, { _id: { $in: objectIds } }],
+    });
+    // Personalize 추천 순서대로 결과 재정렬 및 포맷 변경
+    const orderedAndFormattedResults = recommendedItemIds
+      .map((id) => {
+        // DB에서 조회한 결과 중 현재 ID와 일치하는 아이템 찾기
+        const itemDetail = itemDetailsFromDB.find((item) =>
+          // 현재 ID가 숫자형인지 문자열형인지에 따라 다른 필드와 비교
+          /^\d+$/.test(id) ? item.index == id : item._id.toString() === id
+        );
+
+        // 만약 DB에 해당 아이템이 없으면 null 반환 (데이터 불일치 예외 처리)
+        if (!itemDetail) return null;
+
+        // 원하는 최종 출력 형식으로 객체 생성
+        return {
+          index: itemDetail.index,
+          name: itemDetail.alcoholName, // DB 필드명(alcoholName) -> 출력 필드명(name)
+          degree: itemDetail.degree,
+          image: itemDetail.imageUrl, // DB 필드명(imageUrl) -> 출력 필드명(image)
+        };
+      })
+      .filter((item) => item !== null); // null인 경우 최종 결과에서 제외
+    return orderedAndFormattedResults;
   } catch (error) {
-    console.error("Error getting recommendations:", error);
+    console.error("추천을 받아오는 중 에러가 발생", error);
     throw error;
   }
 };

--- a/Server/server.js
+++ b/Server/server.js
@@ -51,7 +51,7 @@ mongoose.connect(process.env.MONGODB_URI, { useNewUrlParser: true, useUnifiedTop
   .catch((err) => console.error("MongoDB 연결 실패", err));
 
 // 추천 라우터
-app.use("/recommendations", recommendRoutes);
+app.use("/recommend", recommendRoutes);
 //가격별 추천 라우터
 app.use("/recommend/price", priceRecommendRoutes);
 //날씨별 추천 라우터


### PR DESCRIPTION
## 🔧 작업 사항(Summary)<!--- 진행한 작업에 대해 설명해주세요. -->
- [x] mongoDB 초기 축제, 전통주 데이터 없로드 파일에 csv 경로 변경
- [x] gemini 챗봇이 detailPage 대신 alcoholId를 반환하도록 변경
- [x] AWS Personalize의 추천 결과(id)를 받아 mongoDB에 있는 해당 index 전통주 정보를 반환하도록 변경
- [x] bookmark 시 aws interactions에 `_id`가 아닌 index를 저장하도록 변경
- [x] bookmark api body도 index를 전송하도록 변경

## ✨ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## ✅ To-do (선택)
<!--- 작업 예정인 테스크를 작성해 주세요. --->
- [ ] 프론트와 추천 연동
- [ ] 현재 interactions.csv에 이전 `_id` 값이 들어있기 때문에 기회가 된다면 리셋하고 재학습
- [ ] 북마크의 경우 id를 직접 보내는 것이 아닌 토큰으로 기능하도록 수정 필요


## 📸 스크린샷 or Test 결과 (선택)
* 기본 6개 반환히지만 일부 id가 불일치하여 5개 반환함
<img width="1128" height="737" alt="image" src="https://github.com/user-attachments/assets/a0ad3c57-fd3c-4262-91fd-19898b81ae0d" />
<img width="1133" height="691" alt="image" src="https://github.com/user-attachments/assets/71894848-d820-4e1a-9e6b-26b9b2ef8016" />


